### PR TITLE
Using Kubernetes Helm to push ConfigMap changes to Deployments

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        checksum/responseConfigMap: {{ include (print $.Template.BasePath "/responseConfigMap.yaml") . | sha256sum }}
       labels:
         app.kubernetes.io/name: {{ include "upgradeResponder.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
This fix restart the deployment server when user update response configmap
longhorn/longhorn#4312