### PR TITLE
Fix upgrade responder server is hung for a long time

### DIFF
--- a/upgraderesponder/db-cache.go
+++ b/upgraderesponder/db-cache.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const maxSyncRetries = 5
+const maxSyncRetries = 2
 
 type DBCache struct {
 	sync.RWMutex

--- a/upgraderesponder/service.go
+++ b/upgraderesponder/service.go
@@ -30,6 +30,8 @@ const (
 	InfluxDBContinuousQueryDownSampling  = "cq_upgrade_request_down_sampling"
 	InfluxDBContinuousQueryByAppVersion  = "cq_by_app_version_down_sampling"
 	InfluxDBContinuousQueryByCountryCode = "cq_by_country_code_down_sampling"
+
+	influxClientTimeOut = 10 * time.Second
 )
 
 var (
@@ -209,6 +211,7 @@ func NewServer(done chan struct{}, applicationName, responseConfigFilePath, requ
 		cfg := influxcli.HTTPConfig{
 			Addr:               influxURL,
 			InsecureSkipVerify: true,
+			Timeout:            influxClientTimeOut,
 		}
 		if influxUser != "" {
 			cfg.Username = influxUser


### PR DESCRIPTION
Adding a `influxClientTimeOut` and reduce the `maxSyncRetries` so that the server doesn't hang thus allowing other clients to get the response

longhorn/longhorn#6385