### PR TITLE
fix: remove reduntant assigment

### DIFF
--- a/upgraderesponder/service.go
+++ b/upgraderesponder/service.go
@@ -559,7 +559,6 @@ func (s *Server) getFieldsFromRequest(req *CheckUpgradeRequest) map[string]inter
 	fields := map[string]interface{}{
 		utils.ToSnakeCase(ValueFieldKey): ValueFieldValue,
 	}
-	fields[utils.ToSnakeCase(ValueFieldKey)] = ValueFieldValue
 	for k, v := range req.ExtraFieldInfo {
 		if s.ValidateExtraInfo(k, v, extraInfoTypeField) {
 			fields[utils.ToSnakeCase(k)] = v


### PR DESCRIPTION
Updates the getFieldsFromRequest removing a redundant assignment. The key and value pair is assigned in the map initialization.

Fix https://github.com/longhorn/longhorn/issues/11705